### PR TITLE
Fix export default error in Toaster component

### DIFF
--- a/src/components/Toaster.tsx
+++ b/src/components/Toaster.tsx
@@ -53,6 +53,4 @@ export const toast: { [key in TypeOptions]: (content: string | ReactElement) => 
     {}
 );
 
-const Toaster = () => <ToastContainer closeButton={false} icon={false} />;
-
-export default Toaster;
+export const Toaster = () => <ToastContainer closeButton={false} icon={false} />;

--- a/src/ui/ToasterExample.tsx
+++ b/src/ui/ToasterExample.tsx
@@ -1,8 +1,8 @@
 import { Box } from '../components/Box';
 import { Button } from '../components/Button';
 import { DesignSystemProvider } from '../components/DesignSystemProvider';
+import { Toaster, toast } from '../components/Toaster';
 import React from 'react';
-import Toaster, { toast } from '../components/Toaster';
 
 const Example = () => (
     <DesignSystemProvider>


### PR DESCRIPTION
Changed "export default" to "export" to fix an error when using this component in the APP.