### PR TITLE
Bug fix in react-dropzone mobile

### DIFF
--- a/src/components/InputUpload.tsx
+++ b/src/components/InputUpload.tsx
@@ -28,7 +28,7 @@ const InputBoxWrapper = styled.a<GeneratedPropTypes & { [key: string]: any }>`
 
 const InputElement = styled.input``;
 
-export const InputUpload = React.forwardRef((props: InputUploadProps, ref) => {
+export const InputUpload: React.FC<InputUploadProps> = props => {
     const { children, handleFiles, wrapperProps, ...dropzoneOptions } = props;
 
     const { acceptedFiles, getRootProps, getInputProps, open } = useDropzone({
@@ -46,9 +46,9 @@ export const InputUpload = React.forwardRef((props: InputUploadProps, ref) => {
         <InputBoxWrapper {...wrapperProps} {...getRootProps()} onClick={open}>
             <PulseIcon bgG100 borderColor="g50" g600 icon="upload" />
             {!!children && <Box mt={0.75}>{children}</Box>}
-            <InputElement {...getInputProps()} ref={ref} />
+            <InputElement {...getInputProps()} />
         </InputBoxWrapper>
     );
-});
+};
 
 InputUpload.displayName = 'InputUpload';

--- a/src/components/Typography.tsx
+++ b/src/components/Typography.tsx
@@ -18,6 +18,7 @@ const miscVariations = {
 
 const commonStyle = css`
     font-family: ${fonts.families.sans};
+    white-space: pre-wrap;
 
     ${variations(miscVariations)};
     ${variations(setWeightVariations(fonts.weights))};


### PR DESCRIPTION
- Added "white-space: pre-wrap" to Text and Display components to allow multiple lines;
- Refactor code in InputUpload component. "Ref" was causing problems in mobile, so i removed it and converted ForwardRef to FunctionComponent;