### PR TITLE
Multiple fixes in components

### DIFF
--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -13,6 +13,10 @@ export const avatarSizeVariations = {
         ${size('7.5rem')};
     `,
 
+    medium: css`
+        ${size('5.313rem')};
+    `,
+
     small: css`
         ${size('2rem')};
     `

--- a/src/components/GlobalStyle.tsx
+++ b/src/components/GlobalStyle.tsx
@@ -96,6 +96,10 @@ export const GlobalStyle = createGlobalStyle`
     }
   }
 
+  .Toastify__toast-container {
+    z-index: 999999;
+  }
+  
   .Toastify__toast {
     border-radius: 0.5rem;
     box-shadow: 0 0 1.5rem ${rgba(colors.g600, 0.08)};

--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -27,7 +27,7 @@ const Wrapper = styled.div<{ state?: StateTypes } & GeneratedPropTypes>`
 
 export type LabelProps = {
     icon?: string;
-    content: string | number;
+    content: string | number | React.ReactNode;
 } & BoolPropsFromArray<typeof stateTypes> &
     GeneratedPropTypes;
 

--- a/src/components/TextLink.tsx
+++ b/src/components/TextLink.tsx
@@ -1,7 +1,7 @@
 import { BoolProps, GeneratedPropTypes } from '../types';
-import { colors, fonts } from '../theme';
+import { colors, fonts, typography } from '../theme';
 import { ease, generateProps, mq, transitions, variations } from 'styled-gen';
-import { setWeightVariations } from '../utils/typographyHelpers';
+import { setSizeVariations, setWeightVariations } from '../utils/typographyHelpers';
 import styled, { css } from 'styled-components';
 
 const setColorVariation = (color: string, hover: string) => css`
@@ -28,9 +28,9 @@ export const TextLink = styled.a<TextLinkProps>`
     ${transitions('color', 250, ease.outSine)};
 
     cursor: pointer;
-    font-size: inherit;
 
     ${variations(colorVariations)};
-    ${variations(setWeightVariations(fonts.weights))}
+    ${variations(setWeightVariations(fonts.weights))};
+    ${variations(setSizeVariations(typography.text as any))};
     ${generateProps};
 `;

--- a/src/helpers/applyStateColor.ts
+++ b/src/helpers/applyStateColor.ts
@@ -33,7 +33,7 @@ export const applyAlertStateColor = (type: StateTypes) => {
 
 export const applyProgressBarStateColor = (type: StateTypes) => {
     const typePrefix = getTypePrefix(type);
-    const colorCode = typePrefix === 'p' ? 400 : typePrefix === 'w' ? 300 : 600;
+    const colorCode = typePrefix === 'p' ? 400 : typePrefix === 'w' ? 300 : typePrefix === 'e' ? 500 : 600;
 
     return css`
         background-color: ${colors[`${typePrefix}${colorCode}` as Color]};

--- a/src/stories/2-base/Elements/TextLink.stories.tsx
+++ b/src/stories/2-base/Elements/TextLink.stories.tsx
@@ -1,10 +1,11 @@
 /* eslint-disable sort-keys */
 import { TextLink as BaseTextLink, TextLinkProps } from '../../../components/TextLink';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import { fonts } from '../../../theme';
+import { fonts, typography } from '../../../theme';
 import { getGeneratedPropArgs, setGeneratedPropArgs } from '../../../helpers/generatedPropArgs';
 import React from 'react';
 import base from 'paths.macro';
+import getTypographyArgTypes from '../../../helpers/getTypographyArgTypes';
 
 export default {
     argTypes: {
@@ -13,6 +14,7 @@ export default {
             description: 'Pass as bool prop',
             options: Object.keys(fonts?.weights)
         },
+        ...getTypographyArgTypes({ sizes: Object.keys(typography.text) }),
         ...setGeneratedPropArgs()
     },
     parameters: {

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -1,6 +1,7 @@
 /* eslint-disable sort-keys */
 export const typography = {
     display: {
+        large: [36, 44],
         small: { sm: [30, 38], xs: [24, 32] }
     },
     text: {

--- a/src/utils/applyMqProps.ts
+++ b/src/utils/applyMqProps.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-nested-ternary */
 import { FlattenSimpleInterpolation, css } from 'styled-components';
 import { MqProp } from '..';
 import { mq } from 'styled-gen';
@@ -19,6 +20,8 @@ const applyMqProps = (prop: MqProp<any>, callback: Function | string | FlattenSi
         `;
     }
 
+    const keys = !!prop ? Object.keys(prop) : [];
+
     const styleArr = Object.entries(bps).reduce((results: string[], [bpShort, bpName]) => {
         if (!prop?.[bpShort] && !prop?.[bpName]) {
             return results;
@@ -33,15 +36,26 @@ const applyMqProps = (prop: MqProp<any>, callback: Function | string | FlattenSi
             ];
         }
 
+        const nextIndex = keys.indexOf(bpShort) - 1;
+        const nextItem = keys[nextIndex];
+
         return [
             ...results,
             !!prop[bpShort]
-                ? mq.from(
-                      bpShort,
-                      css`
-                          ${applyCallBack(callback, prop[bpShort])}
-                      `
-                  )
+                ? nextIndex >= 0
+                    ? mq.between(
+                          bpShort,
+                          nextItem,
+                          css`
+                              ${applyCallBack(callback, prop[bpShort])}
+                          `
+                      )
+                    : mq.from(
+                          bpShort,
+                          css`
+                              ${applyCallBack(callback, prop[bpShort])}
+                          `
+                      )
                 : mq?.[bpName](css`
                       ${applyCallBack(callback, prop[bpName])}
                   `)


### PR DESCRIPTION
- Added new size for Avatar component: medium;
- Fixed Toaster component z-index;
- Fixed Label component content type;
- Added Text sizes in TextLink component;
- Fixed Progress Bar component error color;
- Added new size for Display: large;
- Fixed a bug in media queries:
    - If we had an object like { md: 3, sm: 6, xs: 12 }, the "md" was ignored and it would applied the "sm" directly;
    - Added a "between" function so now the same object above is applied like this:
       - from "md": 3
       - from "sm" to "md": 6
       - xs